### PR TITLE
fix cargo hack job for bin target

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -67,7 +67,7 @@ jobs:
       - name: cargo install cargo-hack
         uses: taiki-e/install-action@cargo-hack
       - name: cargo hack
-        run: cargo hack --feature-powerset check --all-targets
+        run: cargo hack --feature-powerset check
   msrv:
     runs-on: ubuntu-latest
     # we use a matrix here just because env can't be used in job names

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -66,6 +66,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: cargo install cargo-hack
         uses: taiki-e/install-action@cargo-hack
+      # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
       - name: cargo hack
         run: cargo hack --feature-powerset check
   msrv:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -67,7 +67,7 @@ jobs:
       - name: cargo install cargo-hack
         uses: taiki-e/install-action@cargo-hack
       - name: cargo hack
-        run: cargo hack --feature-powerset check --lib --tests
+        run: cargo hack --feature-powerset check --all-targets
   msrv:
     runs-on: ubuntu-latest
     # we use a matrix here just because env can't be used in job names


### PR DESCRIPTION
`cargo hack --feature-powerset check --lib --tests` failed for workspace that contains a package with only bin target(s).  `--all-targets` flag resolves this

Example of error:

```shell
error: no library targets found in package `foo`
``` 