### PR TITLE
chore: automatically cancel superseded Actions runs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 name: check
 jobs:
   fmt:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+# Spend CI time only on latest ref: https://github.com/jonhoo/rust-ci-conf/pull/5
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 name: no-std
 jobs:
   nostd:

--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+# Spend CI time only on latest ref: https://github.com/jonhoo/rust-ci-conf/pull/5
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 name: safety
 jobs:
   sanitizers:

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+# Spend CI time only on latest ref: https://github.com/jonhoo/rust-ci-conf/pull/5
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   schedule:
     - cron:  '7 7 * * *'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 name: rolling
 jobs:
   # https://twitter.com/mycoliza/status/1571295690063753218

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
   schedule:
     - cron:  '7 7 * * *'
+# Spend CI time only on latest ref: https://github.com/jonhoo/rust-ci-conf/pull/5
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 name: test
 jobs:
   required:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+# Spend CI time only on latest ref: https://github.com/jonhoo/rust-ci-conf/pull/5
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
Noticed while watching one of your streams (thanks for doing those!) that you manually cancelled runs after new pushes to shorten the wait for new runs.

This will automatically cancel runs with the same head ref (i.e. a PR). Note that this will _not_ cancel builds for pushes to branches (such as `main`).

Docs: https://docs.github.com/en/actions/using-jobs/using-concurrency