### PR TITLE
Use rust-toolchain component instead of the archived clippy-check action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -55,9 +55,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           components: clippy
       - name: cargo clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo clippy
   doc:
     # run docs generation on nightly rather than stable. This enables features like
     # https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html which allows an


### PR DESCRIPTION
Hello,

The `actions-rs/clippy-check` action was still used even if the repo is archived since a couple of months, and it was giving me warnings on a project, so I deciced to remove it and use `clippy` from the `rust-toolchain` action since you installed it on the line above.