### PR TITLE
replace actions-rs/clippy-check with giraffate/clippy-action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -55,9 +55,10 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           components: clippy
       - name: cargo clippy
-        uses: actions-rs/clippy-check@v1
+        uses: giraffate/clippy-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: 'github-pr-check'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
   doc:
     # run docs generation on nightly rather than stable. This enables features like
     # https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html which allows an


### PR DESCRIPTION
Hey there,

In relation to https://github.com/jonhoo/rust-ci-conf/pull/18, I found an alternative which checks the "GitHub Checks" nice-to-have. Last commit (as of writing) was 2 months ago, FYI. I know maintenance came up in the discussion on the linked PR.